### PR TITLE
Remove -server from the goals (e.g. run-server -> run)

### DIFF
--- a/getting-started-guide/step1.md
+++ b/getting-started-guide/step1.md
@@ -9,13 +9,13 @@ Navigate to the start directory where your pom.xml file is located. Your pom.xml
 
 Install and run the server
 
-`mvn install liberty:run-server`{{execute}}
+`mvn install liberty:run`{{execute}}
 
 The mvn command initiates a Maven build, during which the target directory is created to store all build-related files.
 
 The install argument specifies the Maven install phase. During this phase, the application is built and packaged into a .war file, an Open Liberty server runtime is downloaded and installed into the target/liberty/wlp directory, a server instance is created and configured in the target/liberty/wlp/usr/servers/GettingStartedServer directory, and the application is installed into that server via loose config.
 
-The liberty:run-server argument specifies the Open Liberty run-server goal, which starts an Open Liberty server instance in the foreground.
+The liberty:run argument specifies the Open Liberty run-server goal, which starts an Open Liberty server instance in the foreground.
 
 For more information on the Liberty Maven plug-in, see its GitHub repository.
 

--- a/getting-started-guide/step5.md
+++ b/getting-started-guide/step5.md
@@ -1,8 +1,8 @@
 ## Starting and stopping the Open Liberty server in the background 
 
-Although you can start and stop the server in the foreground by using the Maven `liberty:run-server` goal, you can also start and stop the server in the background with the Maven `liberty:start-server` and `liberty:stop-server` goals:
+Although you can start and stop the server in the foreground by using the Maven `liberty:run` goal, you can also start and stop the server in the background with the Maven `liberty:start` and `liberty:stop` goals:
 
-`mvn liberty:start-server`{{execute}}
+`mvn liberty:start`{{execute}}
 
-`mvn liberty:stop-server`{{execute}}
+`mvn liberty:stop`{{execute}}
 


### PR DESCRIPTION
This is required to get the katacoda lab to work.